### PR TITLE
Feat/invite members

### DIFF
--- a/client/app/(dashboard)/[workspaceSlug]/[teamKey]/issues/page.tsx
+++ b/client/app/(dashboard)/[workspaceSlug]/[teamKey]/issues/page.tsx
@@ -22,15 +22,24 @@ interface TeamIssuesPageProps {
 
 export default function TeamIssuesPage({ params }: TeamIssuesPageProps) {
   const { teamKey } = use(params)
-  const { currentWorkspace, isLoading } = useWorkspaceStore()
+  const { currentWorkspace, teams, isLoading } = useWorkspaceStore()
   const { issues, loadingStates, selectedIssueId, fetchIssuesByTeam, setSelectedIssue } = useIssueStore()
 
   // Local UI state for view and create modal
   const [view, setView] = useState<'list' | 'board'>('list')
   const [showCreateIssue, setShowCreateIssue] = useState(false)
 
-  // Find the current team
-  const currentTeam = currentWorkspace?.teams.find(team => team.key === teamKey)
+  // Find the current team from the teams array in the store
+  const currentTeam = teams.find(team => team.key === teamKey)
+
+  const { fetchTeams } = useWorkspaceStore()
+
+  // Fetch teams when component mounts to ensure we have latest data
+  useEffect(() => {
+    if (currentWorkspace?.id) {
+      fetchTeams()
+    }
+  }, [currentWorkspace?.id, fetchTeams])
 
   // Fetch issues when workspace changes
   useEffect(() => {

--- a/client/app/(dashboard)/[workspaceSlug]/teams/page.tsx
+++ b/client/app/(dashboard)/[workspaceSlug]/teams/page.tsx
@@ -4,8 +4,11 @@ import React from 'react'
 import { WorkspaceTeams } from '@/components/features/teams/WorkspaceTeams'
 import { CreateTeamDialog } from '@/components/features/teams/CreateTeamDialog'
 import { Team } from '@/types/workspace'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 export default function TeamsPage() {
+  const { fetchTeams } = useWorkspaceStore()
+
   const handleEditTeam = (team: Team) => {
     // TODO: Implement edit team functionality
     console.log('Edit team:', team)
@@ -21,13 +24,17 @@ export default function TeamsPage() {
     console.log('Manage members:', team)
   }
 
+  const handleTeamCreated = () => {
+    fetchTeams()
+  }
+
   return (
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
       <div className="flex items-center justify-between pl-4 pr-4 pt-2 pb-2 border-b border-border">
         <h1 className="text-lg font-bold text-foreground">Teams</h1>
         
-        <CreateTeamDialog />
+        <CreateTeamDialog onTeamCreated={handleTeamCreated} />
       </div>
       
       {/* Main Content */}

--- a/client/components/features/inviteMember/inviteMemberModal.tsx
+++ b/client/components/features/inviteMember/inviteMemberModal.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import * as z from "zod"
+import { Button } from "@/components/ui/atoms/button"
+import { Input } from "@/components/ui/atoms/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/organisms/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/molecules/form"
+import { Mail, CheckCircle, XCircle } from "lucide-react"
+import { useWorkspaceStore } from "@/stores/workspaceStore"
+import api from "@/lib/axios"
+import { toast } from "react-hot-toast"
+
+// Type for API error response
+interface ApiError {
+  response?: {
+    data?: {
+      message?: string
+    }
+  }
+  message?: string
+}
+
+export const inviteMemberSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+})
+
+type InviteMemberFormData = z.infer<typeof inviteMemberSchema>
+
+interface InviteMemberModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function InviteMemberModal({ isOpen, onClose }: InviteMemberModalProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [inviteStatus, setInviteStatus] = useState<{
+    type: 'success' | 'error' | '';
+    message: string;
+  }>({ type: '', message: '' })
+  
+  const currentWorkspace = useWorkspaceStore((state) => state.currentWorkspace)
+  const fetchMembers = useWorkspaceStore((state) => state.fetchMembers)
+
+  const form = useForm<InviteMemberFormData>({
+    resolver: zodResolver(inviteMemberSchema),
+    defaultValues: {
+      email: "",
+    },
+  })
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      form.reset()
+      setInviteStatus({ type: '', message: '' })
+    }
+  }, [isOpen, form])
+
+  const onSubmit = async (data: InviteMemberFormData) => {
+    if (!currentWorkspace) {
+      toast.error("No workspace selected")
+      return
+    }
+
+    setIsLoading(true)
+    setInviteStatus({ type: '', message: '' })
+
+    try {
+      const response = await api.post(`/api/workspace/${currentWorkspace.id}/invite`, {
+        email: data.email.trim().toLowerCase(),
+      })
+
+      if (response.status === 200 || response.status === 201) {
+        setInviteStatus({
+          type: 'success',
+          message: `Invitation sent to ${data.email}!`
+        })
+        
+        // Refresh members list
+        await fetchMembers()
+        
+        // Reset form
+        form.reset()
+        
+        // Close dialog after a short delay
+        setTimeout(() => {
+          onClose()
+          setInviteStatus({ type: '', message: '' })
+        }, 2000)
+      } else {
+        throw new Error("Failed to send invitation")
+      }
+    } catch (error: unknown) {
+      console.error("Failed to invite member:", error)
+      
+      // Show specific error message
+      const errorMessage = error instanceof Error 
+        ? error.message 
+        : typeof error === 'object' && error !== null && 'response' in error
+        ? (error as ApiError).response?.data?.message || "Failed to send invitation"
+        : "Failed to send invitation"
+      
+      setInviteStatus({
+        type: 'error',
+        message: errorMessage
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    onClose()
+    setInviteStatus({ type: '', message: '' })
+    form.reset()
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Invite Team Member</DialogTitle>
+          <DialogDescription>
+            Invite someone to join your workspace and collaborate on projects.
+          </DialogDescription>
+        </DialogHeader>
+        
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email Address</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+                      <Input 
+                        placeholder="colleague@company.com" 
+                        className="pl-10"
+                        {...field} 
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {inviteStatus.message && (
+              <div className={`p-4 rounded-md border ${
+                inviteStatus.type === 'success' 
+                  ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20' 
+                  : 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20'
+              }`}>
+                <div className="flex items-center gap-2 text-sm">
+                  {inviteStatus.type === 'success' ? (
+                    <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400" />
+                  ) : (
+                    <XCircle className="w-4 h-4 text-red-600 dark:text-red-400" />
+                  )}
+                  <span className={
+                    inviteStatus.type === 'success' 
+                      ? 'text-green-700 dark:text-green-300' 
+                      : 'text-red-700 dark:text-red-300'
+                  }>
+                    {inviteStatus.message}
+                  </span>
+                </div>
+              </div>
+            )}
+            
+            <DialogFooter>
+              <Button 
+                type="button" 
+                variant="outline" 
+                onClick={handleClose}
+                disabled={isLoading}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? "Sending..." : "Send Invitation"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/components/features/teams/CreateTeamDialog.tsx
+++ b/client/components/features/teams/CreateTeamDialog.tsx
@@ -83,7 +83,7 @@ export function CreateTeamDialog({ onTeamCreated }: CreateTeamDialogProps) {
         color: data.color || "#3B82F6",
       })
 
-      if (response.data.team) {
+      if (response.data.data?.team) {
         // Refresh teams list
         await fetchTeams()
         

--- a/client/components/layout/Sidebar.tsx
+++ b/client/components/layout/Sidebar.tsx
@@ -27,7 +27,7 @@ export function Sidebar() {
   const teams = useWorkspaceStore((state) => state.teams)
   const { toggleTheme } = useTheme()
   const { data: session } = useSession()
-  const { openCreateIssue } = useModalStore()
+  const { openCreateIssue, openInviteMember } = useModalStore()
   // State for collapsible sections
   const [expandedSections, setExpandedSections] = useState({
     workspace: true,
@@ -184,7 +184,7 @@ export function Sidebar() {
               <SidebarItem
                 icon={<UserPlus size={16} />}
                 label="Invite people"
-                onClick={() => toast.error('This feature is coming soon')}
+                onClick={openInviteMember}
               />
             </nav>
           </CollapsibleSection>

--- a/client/components/ui/organisms/GlobalModals.tsx
+++ b/client/components/ui/organisms/GlobalModals.tsx
@@ -3,6 +3,7 @@ import { useModalStore } from '@/stores/modalStore'
 import { CreateIssueModal } from '@/components/features/issues/CreateIssueModal'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { CreateWorkspaceModal } from '@/components/features/workspace/CreateWorkspaceModal'
+import { InviteMemberModal } from '@/components/features/inviteMember/inviteMemberModal'
 
 export function GlobalModals() {
   const createIssueOpen = useModalStore((s) => s.createIssueOpen)
@@ -10,6 +11,8 @@ export function GlobalModals() {
   const currentWorkspace = useWorkspaceStore((s) => s.currentWorkspace)
   const createWorkspaceOpen = useModalStore((s) => s.createWorkspaceOpen)
   const closeCreateWorkspace = useModalStore((s) => s.closeCreateWorkspace)
+  const inviteMemberOpen = useModalStore((s) => s.inviteMemberOpen)
+  const closeInviteMember = useModalStore((s) => s.closeInviteMember)
 
   return (
     <>
@@ -24,6 +27,12 @@ export function GlobalModals() {
       key="create-workspace-modal"
       isOpen={createWorkspaceOpen}
       onClose={closeCreateWorkspace}
+    />
+
+    <InviteMemberModal
+      key="invite-member-modal"
+      isOpen={inviteMemberOpen}
+      onClose={closeInviteMember}
     />
     </>
   )

--- a/client/stores/modalStore.ts
+++ b/client/stores/modalStore.ts
@@ -4,10 +4,13 @@ import { create } from 'zustand'
 interface ModalState {
   createIssueOpen: boolean
   createWorkspaceOpen: boolean
+  inviteMemberOpen: boolean
   openCreateIssue: () => void
   closeCreateIssue: () => void
   openCreateWorkspace: () => void
   closeCreateWorkspace: () => void
+  openInviteMember: () => void
+  closeInviteMember: () => void
 }
 
 export const useModalStore = create<ModalState>((set) => ({
@@ -20,4 +23,9 @@ export const useModalStore = create<ModalState>((set) => ({
   createWorkspaceOpen: false,
   openCreateWorkspace: () => set({ createWorkspaceOpen: true }),
   closeCreateWorkspace: () => set({ createWorkspaceOpen: false }),
+
+  //Invite Member
+  inviteMemberOpen: false,
+  openInviteMember: () => set({ inviteMemberOpen: true }),
+  closeInviteMember: () => set({ inviteMemberOpen: false }),
 }))


### PR DESCRIPTION
This pull request introduces a new "Invite Member" modal for inviting users to a workspace, integrates it into the sidebar and global modals, and improves the team management data flow to ensure up-to-date information. The most important changes are grouped below by theme.

**New "Invite Member" Feature:**

* Added a new `InviteMemberModal` component for inviting users to a workspace, including form validation, API integration, and user feedback.
* Updated the `Sidebar` to open the invite modal when "Invite people" is clicked, replacing the previous placeholder action. 
* Registered the `InviteMemberModal` in the global modals component and added state management for opening/closing the modal in `modalStore`.

**Team and Workspace Data Consistency:**

* Updated the team issues and teams pages to fetch the latest teams data when necessary, ensuring the UI reflects recent changes such as team creation. ([client/app/(dashboard)/[workspaceSlug]/[teamKey]/issues/page.tsx
* Fixed the response handling in `CreateTeamDialog` to correctly check for the new team in the API response before refreshing the teams list.