### PR TITLE
Feat/issue page

### DIFF
--- a/backend/src/types/controllers/issue.types.ts
+++ b/backend/src/types/controllers/issue.types.ts
@@ -95,3 +95,25 @@ export interface DeleteIssueResponse {
     issueKey: string;
   };
 }
+
+export interface GetIssueByIdResponse {
+    issue: Issue & {
+      creator: {
+        id: string;
+        name: string | null;
+        email: string;
+      };
+      assignee?: {
+        id: string;
+        name: string | null;
+        email: string;
+      };
+      team: {
+        key: string;
+        name: string;
+        color: string;
+      };
+      issueKey: string;
+      commentCount: number;
+    };
+}

--- a/client/app/(dashboard)/[workspaceSlug]/[teamKey]/issues/page.tsx
+++ b/client/app/(dashboard)/[workspaceSlug]/[teamKey]/issues/page.tsx
@@ -5,7 +5,6 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { useIssueStore } from '@/stores/issueStore'
 import { IssueListView } from '@/components/features/issues/IssueListView'
 import { IssueBoardView } from '@/components/features/issues/IssueBoardView'
-import { IssueDetails } from '@/components/features/issues/IssueDetails'
 // import { CreateIssueButton } from '@/components/features/issues/CreateIssueButton'
 // import { ViewToggle } from '@/components/features/issues/ViewToggle'
 import { LoadingSpinner } from '@/components/ui/atoms/loading-spinner'
@@ -21,9 +20,9 @@ interface TeamIssuesPageProps {
 }
 
 export default function TeamIssuesPage({ params }: TeamIssuesPageProps) {
-  const { teamKey } = use(params)
+  const { teamKey, workspaceSlug } = use(params)
   const { currentWorkspace, teams, isLoading } = useWorkspaceStore()
-  const { issues, loadingStates, selectedIssueId, fetchIssuesByTeam, setSelectedIssue } = useIssueStore()
+  const { issues, loadingStates, fetchIssuesByTeam } = useIssueStore()
 
   // Local UI state for view and create modal
   const [view, setView] = useState<'list' | 'board'>('list')
@@ -85,20 +84,11 @@ export default function TeamIssuesPage({ params }: TeamIssuesPageProps) {
       {/* Main Content */}
       <div className="flex-1">
         {view === 'list' ? (
-          <IssueListView issues={Object.values(issues)} isLoading={loadingStates.fetchIssuesByTeam} />
+          <IssueListView issues={Object.values(issues)} isLoading={loadingStates.fetchIssuesByTeam} workspaceSlug={workspaceSlug} />
         ) : (
-          <IssueBoardView issues={Object.values(issues)} />
+          <IssueBoardView issues={Object.values(issues)} workspaceSlug={workspaceSlug} />
         )}
       </div>
-
-      {/* Issue Details Sidebar */}
-      {selectedIssueId && (
-        <IssueDetails 
-          key={`issue-details-${selectedIssueId}`}
-          issueId={selectedIssueId} 
-          onClose={() => setSelectedIssue(null)} 
-        />
-      )}
     </div>
   )
 }

--- a/client/app/(dashboard)/[workspaceSlug]/issue/[issueKey]/page.tsx
+++ b/client/app/(dashboard)/[workspaceSlug]/issue/[issueKey]/page.tsx
@@ -1,0 +1,9 @@
+
+import { IssueDetails } from '@/components/features/issues/IssueDetails'
+
+
+
+export default function IssuePage() {
+
+  return <IssueDetails />
+}

--- a/client/app/(dashboard)/[workspaceSlug]/myissues/page.tsx
+++ b/client/app/(dashboard)/[workspaceSlug]/myissues/page.tsx
@@ -11,9 +11,16 @@ import { IssueBoardView } from '@/components/features/issues/IssueBoardView'
 import { LoadingSpinner } from '@/components/ui/atoms/loading-spinner'
 import { ViewHeader } from '@/components/ui/organisms/ViewHeader'
 import { User } from 'lucide-react'
+import { use } from 'react'
 
+interface MyIssuesPageProps {
+  params: Promise<{
+    workspaceSlug: string
+  }>
+}
 
-export default function MyIssuesPage() {
+export default function MyIssuesPage({ params }: MyIssuesPageProps) {
+  const { workspaceSlug } = use(params)
   const currentWorkspace = useWorkspaceStore((state) => state.currentWorkspace)
   const currentUser = useWorkspaceStore((state) => state.currentUser)
   const isLoading = useWorkspaceStore((state) => state.isLoading)
@@ -75,9 +82,9 @@ export default function MyIssuesPage() {
       {/* Main Content */}
       <div className="flex-1">
         {view === 'list' ? (
-          <IssueListView issues={myIssues} isLoading={loadingStates.fetchIssuesByWorkspace} />
+          <IssueListView issues={myIssues} isLoading={loadingStates.fetchIssuesByWorkspace} workspaceSlug={workspaceSlug} />
         ) : (
-          <IssueBoardView issues={myIssues} />
+          <IssueBoardView issues={myIssues} workspaceSlug={workspaceSlug} />
         )}
       </div>
 

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -4,6 +4,105 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* TipTap Editor Styles */
+.tiptap {
+  outline: none;
+  min-height: 60px; /* Reduced min-height */
+}
+
+.tiptap .is-editor-empty:first-child::before {
+  color: #adb5bd;
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
+.tiptap p {
+  margin: 0.5em 0;
+}
+
+.tiptap h1, .tiptap h2, .tiptap h3, .tiptap h4, .tiptap h5, .tiptap h6 {
+  margin: 1em 0 0.5em 0;
+  font-weight: 600;
+}
+
+.tiptap ul, .tiptap ol {
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+
+.tiptap li {
+  margin: 0.25em 0;
+}
+
+.tiptap blockquote {
+  border-left: 3px solid #e5e7eb;
+  margin: 1em 0;
+  padding-left: 1em;
+  font-style: italic;
+  color: #6b7280;
+}
+
+.tiptap code {
+  background-color: #f3f4f6;
+  padding: 0.2em 0.4em;
+  border-radius: 0.25em;
+  font-family: monospace;
+  font-size: 0.875em;
+}
+
+.tiptap pre {
+  background-color: #f3f4f6;
+  padding: 1em;
+  border-radius: 0.5em;
+  overflow-x: auto;
+}
+
+.tiptap pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+.tiptap strong {
+  font-weight: 600;
+}
+
+.tiptap em {
+  font-style: italic;
+}
+
+.tiptap a {
+  color: #3b82f6;
+  text-decoration: underline;
+}
+
+.tiptap a:hover {
+  color: #2563eb;
+}
+
+/* Dark mode styles */
+.dark .tiptap blockquote {
+  border-left-color: #4b5563;
+  color: #9ca3af;
+}
+
+.dark .tiptap code {
+  background-color: #374151;
+}
+
+.dark .tiptap pre {
+  background-color: #374151;
+}
+
+.dark .tiptap a {
+  color: #60a5fa;
+}
+
+.dark .tiptap a:hover {
+  color: #93c5fd;
+}
+
 @layer base {
   :root {
     --transition-theme: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);

--- a/client/components/features/issues/IssueBoardView.tsx
+++ b/client/components/features/issues/IssueBoardView.tsx
@@ -9,6 +9,7 @@ import { Issue } from '@/types/issue'
 
 interface IssueBoardViewProps {
   issues: Issue[]
+  workspaceSlug: string
 }
 
 // New architecture: use canonical state values from backend/types
@@ -40,7 +41,7 @@ const COLUMNS = [
   }
 ] as const
 
-export function IssueBoardView({ issues }: IssueBoardViewProps) {
+export function IssueBoardView({ issues, workspaceSlug }: IssueBoardViewProps) {
   const { updateIssue } = useIssueStore()
 
   // Group filtered issues by state (using canonical state values)
@@ -91,6 +92,7 @@ export function IssueBoardView({ issues }: IssueBoardViewProps) {
                 <IssueColumn
                   column={column}
                   issues={groupedIssues[column.id] || []}
+                  workspaceSlug={workspaceSlug}
                 />
               </div>
             ))}

--- a/client/components/features/issues/IssueCard.tsx
+++ b/client/components/features/issues/IssueCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useRouter } from 'next/navigation'
 import { Issue } from '@/types/issue'
 import { Badge } from '@/components/ui/atoms/badge'
 import { Avatar, AvatarFallback } from '@/components/ui/atoms/avatar'
@@ -11,10 +12,12 @@ import { ClientDate } from '@/components/ui/atoms/client-date'
 
 interface IssueCardProps {
   issue: Issue
+  workspaceSlug: string
 }
 
-export function IssueCard({ issue }: IssueCardProps) {
+export function IssueCard({ issue, workspaceSlug }: IssueCardProps) {
   const { setSelectedIssue } = useIssueStore()
+  const router = useRouter()
 
   // --- Priority Badge Color ---
   const getPriorityColor = (priority: number) => {
@@ -31,6 +34,7 @@ export function IssueCard({ issue }: IssueCardProps) {
   // --- Card Click Handler ---
   const handleClick = () => {
     setSelectedIssue(issue.id)
+    router.push(`/${workspaceSlug}/issue/${issue.issueKey}`)
   }
 
   // --- Render ---

--- a/client/components/features/issues/IssueColumn.tsx
+++ b/client/components/features/issues/IssueColumn.tsx
@@ -14,9 +14,10 @@ interface IssueColumnProps {
     color: string
   }
   issues: Issue[]
+  workspaceSlug: string
 }
 
-export function IssueColumn({ column, issues }: IssueColumnProps) {
+export function IssueColumn({ column, issues, workspaceSlug }: IssueColumnProps) {
   const getColumnColor = (color: string) => {
     switch (color) {
       case 'yellow': return 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20'
@@ -63,7 +64,7 @@ export function IssueColumn({ column, issues }: IssueColumnProps) {
                       snapshot.isDragging && "opacity-50"
                     )}
                   >
-                    <IssueCard issue={issue} />
+                    <IssueCard issue={issue} workspaceSlug={workspaceSlug} />
                   </div>
                 )}
               </Draggable>

--- a/client/components/features/issues/IssueDetails.tsx
+++ b/client/components/features/issues/IssueDetails.tsx
@@ -246,7 +246,7 @@ export function IssueDetails() {
         {/* Content Grid */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Main Content */}
-          <div className="lg:col-span-2 space-y-6">
+          <div className="lg:col-span-2 space-y-6 relative pr-6">
             {/* Description & Notes */}
             <div className="space-y-3">
               <IssueNotes
@@ -254,6 +254,9 @@ export function IssueDetails() {
                 onUpdate={handleNotesUpdate}
               />
             </div>
+
+            {/* Horizontal Ruler */}
+            <div className="border-t border-border/70 my-6"></div>
 
             {/* Comments Section */}
             <div className="space-y-4">
@@ -285,6 +288,11 @@ export function IssueDetails() {
                   No comments yet. Be the first to comment!
                 </div>
               </div>
+            </div>
+
+            {/* Vertical Ruler - positioned within main content */}
+            <div className="hidden lg:block absolute right-0 top-0 bottom-0">
+              <div className="w-px h-full bg-border/70 -mr-3"></div>
             </div>
           </div>
 

--- a/client/components/features/issues/IssueDetails.tsx
+++ b/client/components/features/issues/IssueDetails.tsx
@@ -1,167 +1,314 @@
 'use client'
 
-import React, { useState } from 'react'
-import { X, Calendar, User, CheckSquare, Flag } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { ArrowLeft, Loader2, Edit3, Clock, Settings, MessageSquare } from 'lucide-react'
 import { Button } from '@/components/ui/atoms/button'
 import { Input } from '@/components/ui/atoms/input'
-import { Label } from '@/components/ui/atoms/label'
-import { AssigneesField } from '@/components/features/issues/AssigneesField'
 import { useIssueStore } from '@/stores/issueStore'
-import { cn } from '@/lib/utils'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/atoms/select'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { IssueNotes } from '@/components/features/issues/IssueNotes'
 import { DueDatePicker } from '@/components/ui/molecules/DueDatePicker'
+import { PriorityCell, StateCell, AssigneeCell } from '@/components/ui/atoms/rowElements'
 
-interface IssueDetailsProps {
-  issueId: string
-  onClose: () => void
-}
+export function IssueDetails() {
+  const router = useRouter()
+  const params = useParams()
+  const { updateIssue, updateNotes, setSelectedIssue, fetchIssuesByWorkspace, isInitialized } = useIssueStore()
+  const { currentWorkspace } = useWorkspaceStore()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [comment, setComment] = useState('')
 
-export function IssueDetails({ issueId, onClose }: IssueDetailsProps) {
-  // Get issue directly from store using the getIssueById selector
-  const issue = useIssueStore(state => state.getIssueById(issueId))
-  const { updateIssue, updateNotes } = useIssueStore()
-  const [isClosing, setIsClosing] = useState(false)
+  // Get issue key from URL params
+  const issueKey = params.issueKey as string
 
-  // If task doesn't exist, don't render
-  if (!issue) {
-    return null
-  }
+  // Get issue from store by searching through all loaded issues
+  const issue = useIssueStore(state => {
+    const allIssues = Object.values(state.issues)
+    return allIssues.find(issue => issue.issueKey === issueKey) || null
+  })
 
-  const handleClose = () => {
-    setIsClosing(true)
-    setTimeout(() => {
-      setIsClosing(false)
-      onClose()
-    }, 300)
+  useEffect(() => {
+    const loadIssue = async () => {
+      if (!issueKey) {
+        setError('No issue key provided')
+        setLoading(false)
+        return
+      }
+
+      // Check if issue is already in store
+      if (issue) {
+        setSelectedIssue(issue.id)
+        setLoading(false)
+        return
+      }
+
+      // If issue not in store and we have a workspace, try to fetch workspace issues
+      if (currentWorkspace && !isInitialized) {
+        try {
+          await fetchIssuesByWorkspace(currentWorkspace.id)
+          // After fetching, check if the issue is now available
+          const updatedIssues = useIssueStore.getState().issues
+          const foundIssue = Object.values(updatedIssues).find(issue => issue.issueKey === issueKey)
+          
+          if (foundIssue) {
+            setSelectedIssue(foundIssue.id)
+            setLoading(false)
+            return
+          }
+        } catch (error) {
+          console.error('Failed to fetch workspace issues:', error)
+        }
+      }
+
+      // If still not found, show error
+      setError(`Issue ${issueKey} not found. Please go back to the issues list and try again.`)
+      setLoading(false)
+    }
+
+    loadIssue()
+  }, [issueKey, issue, currentWorkspace, isInitialized, fetchIssuesByWorkspace, setSelectedIssue])
+
+  const handleBack = () => {
+    router.back()
   }
 
   const handleFieldUpdate = async (field: string, value: string | number) => {
-    await updateIssue(issueId, { [field]: value })
+    if (issue) {
+      try {
+        await updateIssue(issue.id, { [field]: value })
+        // No need to update local state since we're using store directly
+      } catch (error) {
+        console.error('Failed to update issue:', error)
+      }
+    }
   }
 
   const handleNotesUpdate = async (notes: string) => {
-    await updateNotes(issueId, notes)
+    if (issue) {
+      try {
+        await updateNotes(issue.id, notes)
+        // No need to update local state since we're using store directly
+      } catch (error) {
+        console.error('Failed to update notes:', error)
+      }
+    }
+  }
+
+  const handleTitleSave = async (newTitle: string) => {
+    if (issue && newTitle.trim() !== issue.title) {
+      try {
+        await updateIssue(issue.id, { title: newTitle.trim() })
+        // No need to update local state since we're using store directly
+      } catch (error) {
+        console.error('Failed to update title:', error)
+      }
+    }
+    setEditingTitle(false)
+  }
+
+  const handleCommentSubmit = async () => {
+    if (comment.trim() && issue) {
+      // TODO: Implement comment submission logic
+      console.log('Adding comment:', comment)
+      setComment('')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="ml-3 text-muted-foreground">Loading issue...</span>
+      </div>
+    )
+  }
+
+  if (error || !issue) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
+        <p className="text-destructive">{error || 'Issue not found'}</p>
+        <Button onClick={handleBack} variant="ghost" size="sm">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Go Back
+        </Button>
+      </div>
+    )
   }
 
   return (
-    <div className={cn(
-     "absolute top-0 right-0 w-[70vw] h-full bg-background border-l border-border shadow-xl flex flex-col transition-transform duration-300 ease-in-out",
-     isClosing ? "translate-x-full" : "translate-x-0"
-    )}>
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border">
-        <h2 className="text-lg font-semibold text-foreground">Task Details</h2>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleClose}
-          className="h-8 w-8 p-0"
-        >
-          <X size={16} />
-        </Button>
+    <div className="min-h-screen bg-background">
+      {/* Floating Header */}
+      <div className="sticky top-0 z-20 bg-background/90 backdrop-blur-md border-b border-border/10">
+        <div className="max-w-7xl mx-auto px-4 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Button 
+                onClick={handleBack} 
+                variant="ghost" 
+                size="sm"
+                className="h-8 w-8 p-0 hover:bg-muted/50 rounded-full"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+              <div className="flex items-center gap-2">
+                <span className="px-2 py-1 bg-muted/50 rounded-full text-xs font-medium text-muted-foreground">
+                  {issue.issueKey}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  by {issue.creator?.name || 'Unknown'}
+                </span>
+              </div>
+            </div>
+            
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" className="h-7 px-2 text-sm">
+                <Settings className="h-3 w-3 mr-1" />
+                Settings
+              </Button>
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        {/* Title */}
-        <div className="space-y-2">
-          <Label htmlFor="title">Title</Label>
-          <Input
-            id="title"
-            value={issue.title}
-            onChange={(e) => handleFieldUpdate('title', e.target.value)}
-            placeholder="Enter task title"
-          />
+      <div className="max-w-6xl mx-auto px-10 py-6">
+        {/* Priority Bar */}
+        <div className="mb-4">
+          {editingTitle ? (
+            <div className="flex items-center gap-2">
+              <Input
+                value={issue.title}
+                onChange={(e) => handleFieldUpdate('title', e.target.value)}
+                onBlur={() => setEditingTitle(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleTitleSave(e.currentTarget.value)
+                  } else if (e.key === 'Escape') {
+                    setEditingTitle(false)
+                  }
+                }}
+                className="text-2xl font-bold border-none shadow-none focus-visible:ring-0 px-0 py-0 h-auto resize-none bg-transparent leading-tight"
+                style={{ fontSize: '1.5rem', lineHeight: '2rem' }}
+                autoFocus
+              />
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 group">
+              <h1 className="text-2xl font-bold text-foreground leading-tight">
+                {issue.title}
+              </h1>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setEditingTitle(true)}
+                className="h-6 px-2 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-muted/50 text-sm"
+              >
+                <Edit3 className="h-3 w-3 mr-1" />
+                Edit
+              </Button>
+            </div>
+          )}
+          
+          {/* Priority Bar */}
+          <div className="flex items-center gap-4 mt-3 mb-3 rounded-lg">
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-muted-foreground">Priority</span>
+                <PriorityCell issueId={issue.id} priority={issue.priority || 0} />
+              </div>
+              
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-muted-foreground">Status</span>
+                <StateCell issueId={issue.id} state={issue.state || ''} />
+              </div>
+              
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-muted-foreground">Assignee</span>
+                <AssigneeCell issueId={issue.id} assignee={issue.assignee} />
+              </div>
+            </div>
+            
+            <div className="ml-auto flex items-center gap-2">
+              <div className="flex items-center gap-2">
+                <Clock className="h-3 w-3 text-muted-foreground" />
+                <DueDatePicker
+                  value={issue.dueDate}
+                  onChange={dueDate => handleFieldUpdate('dueDate', dueDate ?? '')}
+                />
+              </div>
+            </div>
+          </div>
         </div>
 
-        {/* Status and Priority */}
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <CheckSquare size={16} />
-              Status
-            </Label>
-            <Select
-              value={issue.state || ''}
-              onValueChange={(value) => handleFieldUpdate('state', value)}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select status" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="backlog">Backlog</SelectItem>
-                <SelectItem value="todo">Todo</SelectItem>
-                <SelectItem value="in-progress">In Progress</SelectItem>
-                <SelectItem value="done">Done</SelectItem>
-                <SelectItem value="cancelled">Cancelled</SelectItem>
-              </SelectContent>
-            </Select>
+        {/* Content Grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Main Content */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* Description & Notes */}
+            <div className="space-y-3">
+              <IssueNotes
+                initialContent={issue.notes || ''}
+                onUpdate={handleNotesUpdate}
+              />
+            </div>
+
+            {/* Comments Section */}
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <MessageSquare className="h-4 w-4 text-muted-foreground" />
+                <h3 className="font-semibold text-sm">Comments</h3>
+              </div>
+              
+              {/* Comment Input */}
+              <div className="flex gap-2">
+                <Input
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="Add a comment..."
+                  className="flex-1"
+                />
+                <Button 
+                  onClick={handleCommentSubmit}
+                  disabled={!comment.trim()}
+                  size="sm"
+                >
+                  Comment
+                </Button>
+              </div>
+              
+              {/* Comments List */}
+              <div className="space-y-3">
+                <div className="text-xs text-muted-foreground text-center py-4">
+                  No comments yet. Be the first to comment!
+                </div>
+              </div>
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <Label className="flex items-center gap-2">
-              <Flag size={16} />
-              Priority
-            </Label>
-            <Select
-              value={issue.priority?.toString() ?? '0'}
-              onValueChange={(value) => handleFieldUpdate('priority', Number(value))}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select priority" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="1">Urgent</SelectItem>
-                <SelectItem value="2">High</SelectItem>
-                <SelectItem value="3">Medium</SelectItem>
-                <SelectItem value="4">Low</SelectItem>
-                <SelectItem value="0">None</SelectItem>
-              </SelectContent>
-            </Select>
+          {/* Sidebar */}
+          <div className="space-y-4">
+            {/* Labels */}
+            <div className="bg-card rounded-lg border border-border/20 p-4">
+              <h3 className="font-semibold mb-3 text-sm">Labels</h3>
+              <div className="flex flex-wrap gap-1">
+                {issue.labels && issue.labels.length > 0 ? (
+                  issue.labels.map((label, index) => (
+                    <span
+                      key={index}
+                      className="px-2 py-1 bg-muted/50 rounded-full text-xs font-medium text-muted-foreground"
+                    >
+                      {label}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-xs text-muted-foreground">No labels</span>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
-
-        {/* Due Date */}
-        <div className="flex flex-1 gap-2">
-          <Label className="flex items-center gap-2 text-nowrap pr-2">
-            <Calendar size={16} />
-            Due Date
-          </Label>
-          <DueDatePicker
-            value={issue.dueDate}
-            onChange={dueDate => handleFieldUpdate('dueDate', dueDate ?? '')}
-          />
-        </div>
-
-        {/* Assignees */}
-        <div className="space-y-2">
-          <Label className="flex items-center gap-2">
-            <User size={16} />
-            Assignees
-          </Label>
-          <AssigneesField
-            issueId={issueId}
-            assignee={issue.assignee ? { id: issue.assignee.id, name: issue.assignee.name || 'Unknown' } : undefined}
-            workspaceId={issue.workspaceId}
-          />
-        </div>
-
-        {/* Created By */}
-        <div className="space-y-2">
-          <Label>Created By</Label>
-          <p className="text-sm text-muted-foreground">
-            {issue.creator?.name || '—'}
-          </p>
-        </div>
-
-        {/* Notes */}
-        <div className="space-y-2">
-          <Label>Notes</Label>
-          <IssueNotes
-            initialContent={issue.notes || ''}
-            onUpdate={handleNotesUpdate}
-          />
         </div>
       </div>
     </div>

--- a/client/components/features/issues/IssueListView.tsx
+++ b/client/components/features/issues/IssueListView.tsx
@@ -8,9 +8,10 @@ import { IssuesTableSkeleton } from '@/components/features/issues/IssuesTableSke
 interface IssueListViewProps {
   issues: Issue[]
   isLoading?: boolean
+  workspaceSlug: string
 }
 
-export function IssueListView({ issues, isLoading = false }: IssueListViewProps) {
+export function IssueListView({ issues, isLoading = false, workspaceSlug }: IssueListViewProps) {
 
   return (
     <div className="flex flex-col h-full">
@@ -20,7 +21,7 @@ export function IssueListView({ issues, isLoading = false }: IssueListViewProps)
         {isLoading ? (
           <IssuesTableSkeleton />
         ) : (
-          <IssueTable issues={issues} />
+          <IssueTable issues={issues} workspaceSlug={workspaceSlug} />
         )}
       </div>
     

--- a/client/components/features/issues/IssueNotes.tsx
+++ b/client/components/features/issues/IssueNotes.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef, useCallback } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -14,87 +14,128 @@ interface IssueNotesProps {
 }
 
 export function IssueNotes({ initialContent, onUpdate }: IssueNotesProps) {
+  const updateTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const isUpdatingRef = useRef(false)
+  const onUpdateRef = useRef<((content: string) => void) | null>(null)
+
+  // Update the ref when onUpdate changes
+  useEffect(() => {
+    onUpdateRef.current = onUpdate
+  }, [onUpdate])
+
+  const debouncedUpdate = useCallback((content: string) => {
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current)
+    }
+    
+    updateTimeoutRef.current = setTimeout(() => {
+      if (!isUpdatingRef.current) {
+        onUpdateRef.current?.(content)
+      }
+    }, 500) // 500ms debounce
+  }, []) // Add empty dependency array
+
   const editor = useEditor({
     extensions: [
       StarterKit,
       Placeholder.configure({
-        placeholder: 'Add notes to this issue...',
+        placeholder: 'Add description...',
       }),
     ],
     content: initialContent,
     onUpdate: ({ editor }) => {
       const html = editor.getHTML()
-      onUpdate(html)
+      debouncedUpdate(html)
     },
-    immediatelyRender: false, // This prevents SSR issues
+    immediatelyRender: false, // Fix SSR hydration mismatch
+    editorProps: {
+      attributes: {
+        class: 'min-h-[60px] focus:outline-none text-sm leading-relaxed',
+      },
+    },
   })
 
   useEffect(() => {
-    if (editor && initialContent !== editor.getHTML()) {
-      editor.commands.setContent(initialContent)
+    if (editor && initialContent !== editor.getHTML() && !isUpdatingRef.current) {
+      isUpdatingRef.current = true
+      editor.commands.setContent(initialContent) // Remove emitUpdate option
+      isUpdatingRef.current = false
     }
   }, [initialContent, editor])
 
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current)
+      }
+    }
+  }, [])
+
   if (!editor) {
-    return null // Simple fallback, same on server and client
+    return (
+      <div className="min-h-[60px] text-sm text-muted-foreground">
+        <div>Loading editor...</div>
+      </div>
+    )
   }
 
   const MenuBar = () => (
-    <div className="flex items-center gap-1 p-2 border-b border-border">
+    <div className="flex items-center gap-1 mb-3 opacity-0 hover:opacity-100 transition-opacity group-hover:opacity-100">
       <Button
         variant="ghost"
         size="sm"
         onClick={() => editor.chain().focus().toggleBold().run()}
         className={cn(
-          "h-8 w-8 p-0",
-          editor.isActive('bold') && "bg-muted"
+          "h-7 w-7 p-0 hover:bg-muted/50",
+          editor.isActive('bold') && "bg-muted/50"
         )}
       >
-        <Bold size={14} />
+        <Bold size={12} />
       </Button>
       <Button
         variant="ghost"
         size="sm"
         onClick={() => editor.chain().focus().toggleItalic().run()}
         className={cn(
-          "h-8 w-8 p-0",
-          editor.isActive('italic') && "bg-muted"
+          "h-7 w-7 p-0 hover:bg-muted/50",
+          editor.isActive('italic') && "bg-muted/50"
         )}
       >
-        <Italic size={14} />
+        <Italic size={12} />
       </Button>
       <Button
         variant="ghost"
         size="sm"
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         className={cn(
-          "h-8 w-8 p-0",
-          editor.isActive('bulletList') && "bg-muted"
+          "h-7 w-7 p-0 hover:bg-muted/50",
+          editor.isActive('bulletList') && "bg-muted/50"
         )}
       >
-        <List size={14} />
+        <List size={12} />
       </Button>
       <Button
         variant="ghost"
         size="sm"
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         className={cn(
-          "h-8 w-8 p-0",
-          editor.isActive('orderedList') && "bg-muted"
+          "h-7 w-7 p-0 hover:bg-muted/50",
+          editor.isActive('orderedList') && "bg-muted/50"
         )}
       >
-        <ListOrdered size={14} />
+        <ListOrdered size={12} />
       </Button>
     </div>
   )
 
   return (
-    <div className="border border-border rounded-md">
+    <div className="group">
       <MenuBar />
-      <div className="p-3">
+      <div className="min-h-[60px]">
         <EditorContent
           editor={editor}
-          className="prose prose-sm max-w-none focus:outline-none"
+          className="min-h-[60px] focus:outline-none text-sm leading-relaxed"
         />
       </div>
     </div>

--- a/client/components/features/issues/IssuesTable.tsx
+++ b/client/components/features/issues/IssuesTable.tsx
@@ -1,21 +1,25 @@
 'use client'
 
 import React from 'react'
+import { useRouter } from 'next/navigation'
 import { Issue } from '@/types/issue'
 import { DataTable } from '@/components/ui/organisms/data-table'
 import { issueColumns } from './table/issue-columns'
-// import { useIssueStore } from '@/stores/issueStore'
+import { useIssueStore } from '@/stores/issueStore'
 
 interface IssueTableProps {
   issues: Issue[]
+  workspaceSlug: string  // Add this prop
 }
 
-const IssueTableComponent = ({ issues }: IssueTableProps) => {
-  // const { setSelectedIssue } = useIssueStore()
-
-  // const handleRowClick = (issue: Issue) => {
-  //   setSelectedIssue(issue.id)
-  // }
+const IssueTableComponent = ({ issues, workspaceSlug }: IssueTableProps) => {
+  const { setSelectedIssue } = useIssueStore()
+  const router = useRouter()
+  
+  const handleRowClick = (issue: Issue) => {
+    setSelectedIssue(issue.id)  // Keep your store logic
+    router.push(`/${workspaceSlug}/issue/${issue.issueKey}`)  // Add navigation
+  }
 
   return (
     <DataTable
@@ -25,9 +29,10 @@ const IssueTableComponent = ({ issues }: IssueTableProps) => {
       showPagination={false}
       emptyMessage="No issues found. Create a new issue."
       className="w-full"
+      onRowClick={handleRowClick}
     />  
   )
 }
 
 export const IssueTable = React.memo(IssueTableComponent)
-IssueTable.displayName = 'IssueTable' 
+IssueTable.displayName = 'IssueTable'

--- a/client/components/features/issues/table/IssueRow.tsx
+++ b/client/components/features/issues/table/IssueRow.tsx
@@ -5,13 +5,17 @@ import { flexRender, Row } from "@tanstack/react-table"
 
 interface IssueRowProps<TData> {
   row: Row<TData>
+  onRowClick?: (row: TData) => void
 }
 
-export function IssueRow<TData>({ row }: IssueRowProps<TData>) {
+export function IssueRow<TData>({ row, onRowClick }: IssueRowProps<TData>) {
   const cells = row.getVisibleCells()
   
   return (
-    <TableRow className="hover:bg-muted/50 transition-colors border-0 flex items-center">
+    <TableRow 
+      className="hover:bg-muted/50 transition-colors border-0 flex items-center"
+      onClick={() => onRowClick?.(row.original)}
+    >
       {/* Priority */}
       <TableCell className="px-4 py-2 w-12 flex-shrink-0">
         {flexRender(cells[0].column.columnDef.cell, cells[0].getContext())}

--- a/client/components/ui/organisms/data-table.tsx
+++ b/client/components/ui/organisms/data-table.tsx
@@ -34,6 +34,7 @@ interface DataTableProps<TData, TValue> {
   emptyMessage?: string
   showRowSelection?: boolean
   groupBy?: string
+  onRowClick?: (row: TData) => void
 }
 
 // State order for grouping
@@ -55,7 +56,8 @@ export function DataTable<TData, TValue>({
   showPagination = true,
   className,
   emptyMessage = "No data found",
-  groupBy = "state"
+  groupBy = "state",
+  onRowClick
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
@@ -137,7 +139,7 @@ export function DataTable<TData, TValue>({
                       if (!row) return null
                       
                       return (
-                        <IssueRow<TData> key={row.id} row={row} />
+                        <IssueRow<TData> key={row.id} row={row} onRowClick={onRowClick} />
                       )
                     })}
                   </React.Fragment>

--- a/client/services/issueService.ts
+++ b/client/services/issueService.ts
@@ -8,6 +8,12 @@ export const issueService = {
     return response.data.issues || []
   },
 
+  // Get an issue by id
+  getIssueById: async (issueId: string): Promise<Issue> => {
+    const response = await api.get(`/api/issues/${issueId}`)
+    return response.data.issue
+  },
+
   // Get all issues for a team
   getIssuesByTeam: async (teamId: string): Promise<Issue[]> => {
     const response = await api.get(`/api/team/${teamId}/issues`)

--- a/client/stores/issueStore.ts
+++ b/client/stores/issueStore.ts
@@ -33,6 +33,7 @@ interface IssueActions {
   getIssuesByState: (state: string) => Issue[]
   getIssuesByAssignee: (assigneeId: string) => Issue[]
   getIssuesArray: () => Issue[]
+  fetchIssueById: (issueId: string) => Promise<Issue | null>
 }
 
 type IssueStore = IssueState & IssueActions
@@ -87,6 +88,35 @@ export const useIssueStore = create<IssueStore>()(
           }))
           console.error('Failed to fetch issues:', error)
           toast.error('Failed to fetch issues')
+        }
+      },
+
+      // Fetch issue by id
+      fetchIssueById: async (issueId: string) => {
+        const operationId = 'fetchIssueById'
+        set(state => ({
+          loadingStates: { ...state.loadingStates, [operationId]: true },
+          errors: { ...state.errors, [operationId]: '' }
+        }))
+        try {
+          const issue = await issueService.getIssueById(issueId)
+          if (issue) {
+            set(state => ({
+              issues: { ...state.issues, [issue.id]: issue },
+              issueIds: state.issueIds.includes(issue.id) ? state.issueIds : [...state.issueIds, issue.id],
+              loadingStates: { ...state.loadingStates, [operationId]: false }
+            }))
+            return issue
+          }
+          return null
+        } catch (error) {
+          set(state => ({
+            errors: { ...state.errors, [operationId]: 'Failed to fetch issue' },
+            loadingStates: { ...state.loadingStates, [operationId]: false }
+          }))
+          console.error('Failed to fetch issue:', error)
+          toast.error('Failed to fetch issue')
+          return null
         }
       },
 


### PR DESCRIPTION
This pull request introduces a new backend API endpoint to fetch an issue by its ID, updates the types accordingly, and refactors the frontend to support direct navigation to issue details via a dedicated route. It also improves the Issue Board and List views to pass the workspace slug for routing, and adds TipTap editor styles. The sidebar-based issue details view is removed in favor of a full-page details view.

**Backend API Enhancements:**

* Added a new `getIssueById` controller and route (`GET /issues/:issueId`) to fetch a single issue with related data, and updated types to include `GetIssueByIdResponse`. 

**Frontend Routing and Issue Details Refactor:**

* Removed the sidebar Issue Details from the team issues page and introduced a new route (`/[workspaceSlug]/issue/[issueKey]`) that renders the `IssueDetails` component as a full page. 
* Updated the `IssueCard`, `IssueColumn`, `IssueBoardView`, and `IssueListView` components to accept and use `workspaceSlug` for navigation, enabling direct linking to issue details.

**UI/UX Improvements:**

* Added comprehensive TipTap editor styles to `globals.css` for consistent rich-text editing experience, including dark mode support.