### PR TITLE
fix: prevent auto row click in IssueRow component

### DIFF
--- a/client/components/features/issues/table/IssueRow.tsx
+++ b/client/components/features/issues/table/IssueRow.tsx
@@ -2,6 +2,7 @@
 
 import { TableCell, TableRow } from "@/components/ui/molecules/table"
 import { flexRender, Row } from "@tanstack/react-table"
+import { SyntheticEvent } from "react"
 
 interface IssueRowProps<TData> {
   row: Row<TData>
@@ -11,10 +12,29 @@ interface IssueRowProps<TData> {
 export function IssueRow<TData>({ row, onRowClick }: IssueRowProps<TData>) {
   const cells = row.getVisibleCells()
   
+  const handleRowClick = (e: SyntheticEvent) => {
+    // Check if the event target is within any dropdown menu
+    const target = e.target as Element
+    
+    if (target.closest('[data-radix-dropdown-menu-trigger]')) {
+      return
+    }
+    
+    if (target.closest('[data-radix-dropdown-menu-content]')) {
+      return
+    }
+    
+    if (target.closest('[role="menuitem"]')) {
+      return
+    }
+    
+    onRowClick?.(row.original)
+  }
+  
   return (
     <TableRow 
       className="hover:bg-muted/50 hover:scale-101 transition-all duration-300 border-0 cursor-pointer flex items-center"
-      onClick={() => onRowClick?.(row.original)}
+      onClick={handleRowClick}
     >
       {/* Priority */}
       <TableCell className="px-4 py-2 w-12 hover:scale-101 transition-all duration-300 flex-shrink-0">


### PR DESCRIPTION
- Implemented a new click handler for the IssueRow component to prevent row clicks when interacting with dropdown menus.
- This change improves user experience by ensuring that dropdown interactions do not trigger row selection.